### PR TITLE
Optionally set the 'overlap simple' flag for every exported glyph

### DIFF
--- a/src/fontra_compile/compile_fontmake_action.py
+++ b/src/fontra_compile/compile_fontmake_action.py
@@ -20,6 +20,7 @@ from fontTools.ufoLib import UFOReaderWriter
 class CompileFontMakeAction:
     destination: str
     options: dict[str, str] = field(default_factory=dict)
+    setOverlapSimpleFlag: bool = False
     input: ReadableFontBackend | None = field(init=False, default=None)
 
     @asynccontextmanager
@@ -45,6 +46,10 @@ class CompileFontMakeAction:
             designspacePath = tmpDir / "temp.designspace"
 
             dsBackend = newFileSystemBackend(designspacePath)
+
+            if self.setOverlapSimpleFlag:
+                assert hasattr(dsBackend, "setOverlapSimpleFlag")
+                dsBackend.setOverlapSimpleFlag = True
 
             async with aclosing(dsBackend):
                 await copyFont(self.input, dsBackend, continueOnError=continueOnError)


### PR DESCRIPTION
Part of the fix for https://github.com/googlefonts/fontra/issues/1450: optionally set the overlap flag for all glyphs.