### PR TITLE
Interpolating component axis values across the "default" border

### DIFF
--- a/src/fontra_compile/builder.py
+++ b/src/fontra_compile/builder.py
@@ -848,7 +848,7 @@ def axisTuple(axis, fixAsymmetricAxes=True) -> tuple[float, float, float]:
         # To work around it, we extend either side of the axis so the distance between
         # minValue and defaultValue becomes the same as the distance between defaultValue
         # and maxValue.
-        # The downside if this approach is that axis values will no longer be clipped to
+        # The downside of this approach is that axis values will no longer be clipped to
         # their original minimum or maximum, so we may create new edge cases here.
         minDiff = defaultValue - minValue
         maxDiff = maxValue - defaultValue

--- a/tests/data/notosanscjksc.otf.ttx
+++ b/tests/data/notosanscjksc.otf.ttx
@@ -21,12 +21,12 @@
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
     <fontRevision value="1.0"/>
-    <checkSumAdjustment value="0x37334ca6"/>
+    <checkSumAdjustment value="0x7d2263a6"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000011"/>
     <unitsPerEm value="1000"/>
-    <created value="Mon Jul 15 08:25:46 2024"/>
-    <modified value="Mon Jul 15 08:25:46 2024"/>
+    <created value="Mon Jul 15 13:01:57 2024"/>
+    <modified value="Mon Jul 15 13:01:57 2024"/>
     <xMin value="0"/>
     <yMin value="-120"/>
     <xMax value="1000"/>
@@ -539,7 +539,7 @@
         <Format value="1"/>
         <VarRegionList>
           <!-- RegionAxisCount=14 -->
-          <!-- RegionCount=43 -->
+          <!-- RegionCount=45 -->
           <Region index="0">
             <VarRegionAxis index="0">
               <StartCoord value="0.0"/>
@@ -2064,9 +2064,9 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="2">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <StartCoord value="-0.99"/>
+              <PeakCoord value="-0.99"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
               <StartCoord value="0.0"/>
@@ -2137,13 +2137,13 @@
             </VarRegionAxis>
             <VarRegionAxis index="2">
               <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
-              <EndCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
               <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="4">
               <StartCoord value="0.0"/>
@@ -2204,18 +2204,18 @@
             </VarRegionAxis>
             <VarRegionAxis index="1">
               <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="2">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
               <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
-              <EndCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="4">
               <StartCoord value="0.0"/>
@@ -2276,8 +2276,8 @@
             </VarRegionAxis>
             <VarRegionAxis index="1">
               <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
-              <EndCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="2">
               <StartCoord value="-1.0"/>
@@ -2310,8 +2310,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="8">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="9">
@@ -2382,14 +2382,14 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="8">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="9">
               <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="10">
               <StartCoord value="0.0"/>
@@ -2424,8 +2424,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="2">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
@@ -2445,8 +2445,8 @@
             </VarRegionAxis>
             <VarRegionAxis index="6">
               <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="7">
               <StartCoord value="0.0"/>
@@ -2454,14 +2454,14 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="8">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="9">
               <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
-              <EndCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="10">
               <StartCoord value="0.0"/>
@@ -2492,12 +2492,12 @@
             </VarRegionAxis>
             <VarRegionAxis index="1">
               <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="2">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
@@ -2516,9 +2516,9 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="6">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
-              <EndCoord value="0.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="7">
               <StartCoord value="0.0"/>
@@ -2526,8 +2526,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="8">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="9">
@@ -2588,8 +2588,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="6">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="7">
@@ -2604,8 +2604,8 @@
             </VarRegionAxis>
             <VarRegionAxis index="9">
               <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="10">
               <StartCoord value="0.0"/>
@@ -2636,8 +2636,8 @@
             </VarRegionAxis>
             <VarRegionAxis index="1">
               <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
-              <EndCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="2">
               <StartCoord value="-1.0"/>
@@ -2645,8 +2645,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="4">
@@ -2708,8 +2708,8 @@
             </VarRegionAxis>
             <VarRegionAxis index="1">
               <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="2">
               <StartCoord value="-1.0"/>
@@ -2732,8 +2732,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="6">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="7">
@@ -2748,8 +2748,8 @@
             </VarRegionAxis>
             <VarRegionAxis index="9">
               <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
-              <EndCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="10">
               <StartCoord value="0.0"/>
@@ -2789,8 +2789,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="4">
@@ -2804,9 +2804,9 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="6">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="7">
               <StartCoord value="0.0"/>
@@ -2820,8 +2820,8 @@
             </VarRegionAxis>
             <VarRegionAxis index="9">
               <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="10">
               <StartCoord value="0.0"/>
@@ -2861,8 +2861,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="4">
@@ -2919,8 +2919,8 @@
           <Region index="33">
             <VarRegionAxis index="0">
               <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="1">
               <StartCoord value="0.0"/>
@@ -2949,8 +2949,8 @@
             </VarRegionAxis>
             <VarRegionAxis index="6">
               <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
-              <EndCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="7">
               <StartCoord value="0.0"/>
@@ -3005,8 +3005,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="4">
@@ -3021,8 +3021,8 @@
             </VarRegionAxis>
             <VarRegionAxis index="6">
               <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="7">
               <StartCoord value="0.0"/>
@@ -3030,14 +3030,14 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="8">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="9">
               <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
-              <EndCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="10">
               <StartCoord value="0.0"/>
@@ -3077,8 +3077,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="4">
@@ -3135,13 +3135,13 @@
           <Region index="36">
             <VarRegionAxis index="0">
               <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
-              <EndCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="1">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
-              <EndCoord value="0.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="2">
               <StartCoord value="-1.0"/>
@@ -3149,8 +3149,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="4">
@@ -3165,8 +3165,8 @@
             </VarRegionAxis>
             <VarRegionAxis index="6">
               <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
-              <EndCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="7">
               <StartCoord value="0.0"/>
@@ -3174,8 +3174,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="8">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="9">
@@ -3211,13 +3211,13 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="1">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="2">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="3">
@@ -3256,8 +3256,8 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="10">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="11">
@@ -3328,9 +3328,9 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="10">
-              <StartCoord value="0.0"/>
-              <PeakCoord value="1.0"/>
-              <EndCoord value="1.0"/>
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
+              <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="11">
               <StartCoord value="0.0"/>
@@ -3401,12 +3401,12 @@
             </VarRegionAxis>
             <VarRegionAxis index="10">
               <StartCoord value="0.0"/>
-              <PeakCoord value="0.0"/>
-              <EndCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="11">
-              <StartCoord value="-1.0"/>
-              <PeakCoord value="-1.0"/>
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="12">
@@ -3452,6 +3452,78 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
             <VarRegionAxis index="6">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="7">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="8">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="9">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="10">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="11">
+              <StartCoord value="-1.0"/>
+              <PeakCoord value="-1.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="12">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="13">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="41">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="2">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="3">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="4">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="5">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="6">
               <StartCoord value="-1.0"/>
               <PeakCoord value="-1.0"/>
               <EndCoord value="0.0"/>
@@ -3492,7 +3564,79 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
           </Region>
-          <Region index="41">
+          <Region index="42">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="2">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="3">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="4">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.55554"/>
+              <EndCoord value="0.55554"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="5">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="6">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="7">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="8">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="9">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="10">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="11">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="12">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="13">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="43">
             <VarRegionAxis index="0">
               <StartCoord value="0.0"/>
               <PeakCoord value="0.0"/>
@@ -3564,7 +3708,7 @@
               <EndCoord value="0.0"/>
             </VarRegionAxis>
           </Region>
-          <Region index="42">
+          <Region index="44">
             <VarRegionAxis index="0">
               <StartCoord value="0.0"/>
               <PeakCoord value="0.0"/>
@@ -3681,9 +3825,9 @@
           <NumShorts value="0"/>
           <!-- VarRegionCount=4 -->
           <VarRegionIndex index="0" value="3"/>
-          <VarRegionIndex index="1" value="4"/>
-          <VarRegionIndex index="2" value="21"/>
-          <VarRegionIndex index="3" value="22"/>
+          <VarRegionIndex index="1" value="21"/>
+          <VarRegionIndex index="2" value="22"/>
+          <VarRegionIndex index="3" value="23"/>
         </VarData>
         <VarData index="4">
           <!-- ItemCount=0 -->
@@ -3702,22 +3846,22 @@
           <VarRegionIndex index="10" value="15"/>
           <VarRegionIndex index="11" value="16"/>
           <VarRegionIndex index="12" value="17"/>
-          <VarRegionIndex index="13" value="23"/>
+          <VarRegionIndex index="13" value="24"/>
           <VarRegionIndex index="14" value="18"/>
           <VarRegionIndex index="15" value="19"/>
-          <VarRegionIndex index="16" value="24"/>
-          <VarRegionIndex index="17" value="25"/>
-          <VarRegionIndex index="18" value="26"/>
+          <VarRegionIndex index="16" value="25"/>
+          <VarRegionIndex index="17" value="26"/>
+          <VarRegionIndex index="18" value="27"/>
           <VarRegionIndex index="19" value="20"/>
-          <VarRegionIndex index="20" value="27"/>
-          <VarRegionIndex index="21" value="28"/>
-          <VarRegionIndex index="22" value="29"/>
-          <VarRegionIndex index="23" value="30"/>
-          <VarRegionIndex index="24" value="31"/>
-          <VarRegionIndex index="25" value="32"/>
-          <VarRegionIndex index="26" value="33"/>
-          <VarRegionIndex index="27" value="34"/>
-          <VarRegionIndex index="28" value="35"/>
+          <VarRegionIndex index="20" value="28"/>
+          <VarRegionIndex index="21" value="29"/>
+          <VarRegionIndex index="22" value="30"/>
+          <VarRegionIndex index="23" value="31"/>
+          <VarRegionIndex index="24" value="32"/>
+          <VarRegionIndex index="25" value="33"/>
+          <VarRegionIndex index="26" value="34"/>
+          <VarRegionIndex index="27" value="35"/>
+          <VarRegionIndex index="28" value="36"/>
         </VarData>
         <VarData index="5">
           <!-- ItemCount=0 -->
@@ -3725,7 +3869,7 @@
           <!-- VarRegionCount=11 -->
           <VarRegionIndex index="0" value="0"/>
           <VarRegionIndex index="1" value="4"/>
-          <VarRegionIndex index="2" value="22"/>
+          <VarRegionIndex index="2" value="23"/>
           <VarRegionIndex index="3" value="7"/>
           <VarRegionIndex index="4" value="8"/>
           <VarRegionIndex index="5" value="9"/>
@@ -3733,7 +3877,7 @@
           <VarRegionIndex index="7" value="11"/>
           <VarRegionIndex index="8" value="12"/>
           <VarRegionIndex index="9" value="13"/>
-          <VarRegionIndex index="10" value="36"/>
+          <VarRegionIndex index="10" value="37"/>
         </VarData>
         <VarData index="6">
           <!-- ItemCount=0 -->
@@ -3741,9 +3885,9 @@
           <!-- VarRegionCount=17 -->
           <VarRegionIndex index="0" value="3"/>
           <VarRegionIndex index="1" value="4"/>
-          <VarRegionIndex index="2" value="21"/>
+          <VarRegionIndex index="2" value="22"/>
           <VarRegionIndex index="3" value="5"/>
-          <VarRegionIndex index="4" value="22"/>
+          <VarRegionIndex index="4" value="23"/>
           <VarRegionIndex index="5" value="6"/>
           <VarRegionIndex index="6" value="7"/>
           <VarRegionIndex index="7" value="8"/>
@@ -3752,10 +3896,10 @@
           <VarRegionIndex index="10" value="12"/>
           <VarRegionIndex index="11" value="15"/>
           <VarRegionIndex index="12" value="17"/>
-          <VarRegionIndex index="13" value="37"/>
-          <VarRegionIndex index="14" value="38"/>
-          <VarRegionIndex index="15" value="39"/>
-          <VarRegionIndex index="16" value="40"/>
+          <VarRegionIndex index="13" value="38"/>
+          <VarRegionIndex index="14" value="39"/>
+          <VarRegionIndex index="15" value="40"/>
+          <VarRegionIndex index="16" value="41"/>
         </VarData>
         <VarData index="7">
           <!-- ItemCount=0 -->
@@ -3765,15 +3909,15 @@
           <VarRegionIndex index="1" value="4"/>
           <VarRegionIndex index="2" value="5"/>
           <VarRegionIndex index="3" value="6"/>
-          <VarRegionIndex index="4" value="7"/>
+          <VarRegionIndex index="4" value="42"/>
           <VarRegionIndex index="5" value="8"/>
           <VarRegionIndex index="6" value="10"/>
           <VarRegionIndex index="7" value="11"/>
           <VarRegionIndex index="8" value="13"/>
           <VarRegionIndex index="9" value="15"/>
           <VarRegionIndex index="10" value="16"/>
-          <VarRegionIndex index="11" value="37"/>
-          <VarRegionIndex index="12" value="38"/>
+          <VarRegionIndex index="11" value="38"/>
+          <VarRegionIndex index="12" value="39"/>
         </VarData>
         <VarData index="8">
           <!-- ItemCount=0 -->
@@ -3783,17 +3927,17 @@
           <VarRegionIndex index="1" value="4"/>
           <VarRegionIndex index="2" value="5"/>
           <VarRegionIndex index="3" value="6"/>
-          <VarRegionIndex index="4" value="7"/>
+          <VarRegionIndex index="4" value="42"/>
           <VarRegionIndex index="5" value="8"/>
           <VarRegionIndex index="6" value="10"/>
           <VarRegionIndex index="7" value="11"/>
           <VarRegionIndex index="8" value="13"/>
           <VarRegionIndex index="9" value="15"/>
           <VarRegionIndex index="10" value="17"/>
-          <VarRegionIndex index="11" value="38"/>
-          <VarRegionIndex index="12" value="39"/>
-          <VarRegionIndex index="13" value="41"/>
-          <VarRegionIndex index="14" value="42"/>
+          <VarRegionIndex index="11" value="39"/>
+          <VarRegionIndex index="12" value="40"/>
+          <VarRegionIndex index="13" value="43"/>
+          <VarRegionIndex index="14" value="44"/>
         </VarData>
         <VarData index="9">
           <!-- ItemCount=0 -->
@@ -3928,8 +4072,8 @@
           <SparseVarRegionAxis index="0">
             <AxisIndex value="4"/>
             <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
+            <PeakCoord value="0.55554"/>
+            <EndCoord value="0.55554"/>
           </SparseVarRegionAxis>
         </Region>
         <Region index="8">
@@ -4072,7 +4216,7 @@
         <Item index="0" value="[0, 0, -940, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"/>
         <Item index="1" value="[16384, 1638, 1638, 1638, 1638, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -16384, 0, 0, 0, 0, 0, 0, 0, -16384, 0, 0, 0, 0, -14746, -14746, 0, 0, 0, 0, 0, 0, 0, 8192, 8192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16384, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16384, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -14746, 0, 0, 0, 0, 0, 0, 0, 0, 16384, 0, 0, 0, 0, 0]"/>
         <Item index="2" value="[-70, 0, -470, 45, -25, 25, -100, 100, 0, 0, 0, 0, 0]"/>
-        <Item index="3" value="[12073, 0, 0, -15557, 0, 0, -12778, 0, 4312, 0, -6820, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -3310, 0, 0, 0, 0]"/>
+        <Item index="3" value="[12073, 0, 0, -15557, 0, 0, -7761, 0, 4312, 0, -4311, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -3310, 0, 0, 0, 0]"/>
       </MultiVarData>
       <MultiVarData index="2" Format="1">
         <Format value="1"/>
@@ -4095,9 +4239,9 @@
         <Item index="0" value="[0, 0, -940, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"/>
         <Item index="1" value="[16384, 1638, 1638, 1638, 1638, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -16384, 0, 0, 0, 0, 0, 0, 0, -16384, 0, 0, 0, 0, -14746, -14746, 0, 0, 0, 0, 0, 0, 0, 8192, 8192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16384, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16384, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -8192, 0, 0, 0, 0, 0]"/>
         <Item index="2" value="[-70, 0, -470, 45, -25, 25, -100, 100, 0, 0, 0, 0, 0, 0, 0]"/>
-        <Item index="3" value="[12073, 0, 0, -15557, 0, 0, -12778, 0, 4312, 0, -6820, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"/>
+        <Item index="3" value="[12073, 0, 0, -15557, 0, 0, -7761, 0, 4312, 0, -4311, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"/>
         <Item index="4" value="[-70, 0, -470, 0, 0, -940, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1000, 0, 0, -100, 0, 25, 0, 0, 0]"/>
-        <Item index="5" value="[12073, 0, 0, 0, 0, -15557, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16384, 0, 16384, 0, 0, -6820, 0, 0, 0]"/>
+        <Item index="5" value="[12073, 0, 0, 0, 0, -15401, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16384, 0, 16384, 0, 0, -4311, 0, 0, 0]"/>
       </MultiVarData>
       <MultiVarData index="3" Format="1">
         <Format value="1"/>


### PR DESCRIPTION
This fixes #45.

Variable component axis values can interpolate across the "default" border.

For example if an axis goes from 0 to 1000 with the default at 200, a variable
component may interpolate this from 100 to 600. In the VARC table, all axis
values will be normalized to (-1, 0, +1). So 100 would normalize to -0.5 and 600
would normalize to +0.5. But this means that interpolation does not work the
same in the normalized space. For example, the midpoint between -0.5 and +0.5
is 0, but the midpoint between 100 and 600 is 350, which would normalize to
0.1875. This is obviously a problem.

To work around it, we extend either side of the axis so the distance between
minValue and defaultValue becomes the same as the distance between defaultValue
and maxValue.

The downside of this approach is that axis values will no longer be clipped to
their original minimum or maximum, so we may create new edge cases here.

