### PR TITLE
Fix glyphDataFormat for CFF2 (VARC) output

### DIFF
--- a/src/fontra_compile/__main__.py
+++ b/src/fontra_compile/__main__.py
@@ -16,6 +16,11 @@ async def main_async() -> None:
         help="Comma- or space-delimited list of glyph names to include. "
         "When not given, include all glyphs.",
     )
+    parser.add_argument(
+        "--no-cff-subroutinize",
+        action="store_true",
+        help="Don't perform CFF subroutinizing.",
+    )
 
     args = parser.parse_args()
     sourceFontPath = pathlib.Path(args.source_font).resolve()
@@ -27,6 +32,7 @@ async def main_async() -> None:
         reader=reader,
         requestedGlyphNames=glyphNames,
         buildCFF2=outputFontPath.suffix.lower() == ".otf",
+        subroutinize=not args.no_cff_subroutinize,
     )
     await builder.setup()
     ttFont = await builder.build()

--- a/src/fontra_compile/builder.py
+++ b/src/fontra_compile/builder.py
@@ -150,6 +150,7 @@ class Builder:
     reader: ReadableFontBackend  # a Fontra Backend, such as DesignspaceBackend
     requestedGlyphNames: list = field(default_factory=list)
     buildCFF2: bool = False
+    subroutinize: bool = True
 
     async def setup(self) -> None:
         self.glyphMap = await self.reader.getGlyphMap()
@@ -497,7 +498,7 @@ class Builder:
         builder.setupOS2()
         builder.setupPost()
 
-        if self.buildCFF2:
+        if self.buildCFF2 and self.subroutinize:
             cffsubr.subroutinize(builder.font)
 
         return builder.font

--- a/src/fontra_compile/builder.py
+++ b/src/fontra_compile/builder.py
@@ -442,7 +442,9 @@ class Builder:
     async def buildFont(self) -> TTFont:
         builder = FontBuilder(
             await self.reader.getUnitsPerEm(),
-            glyphDataFormat=0 if self.buildCFF2 else 1,
+            glyphDataFormat=(
+                0 if self.buildCFF2 else 1
+            ),  # FIXME: set only for cubic-in-glyf
             isTTF=not self.buildCFF2,
         )
 

--- a/src/fontra_compile/builder.py
+++ b/src/fontra_compile/builder.py
@@ -442,7 +442,7 @@ class Builder:
     async def buildFont(self) -> TTFont:
         builder = FontBuilder(
             await self.reader.getUnitsPerEm(),
-            glyphDataFormat=1,
+            glyphDataFormat=0 if self.buildCFF2 else 1,
             isTTF=not self.buildCFF2,
         )
 

--- a/src/fontra_compile/compile_varc_action.py
+++ b/src/fontra_compile/compile_varc_action.py
@@ -15,6 +15,7 @@ from .builder import Builder
 class FontraCompileAction:
     destination: str
     input: ReadableFontBackend | None = field(init=False, default=None)
+    subroutinize: bool = True
 
     @asynccontextmanager
     async def connect(
@@ -33,7 +34,9 @@ class FontraCompileAction:
         outputFontPath = outputDir / self.destination
         assert self.input is not None
         builder = Builder(
-            reader=self.input, buildCFF2=outputFontPath.suffix.lower() == ".otf"
+            reader=self.input,
+            buildCFF2=outputFontPath.suffix.lower() == ".otf",
+            subroutinize=self.subroutinize,
         )
         await builder.setup()
         ttFont = await builder.build()

--- a/tests/data/MutatorSans.otf.ttx
+++ b/tests/data/MutatorSans.otf.ttx
@@ -77,7 +77,7 @@
     <lowestRecPPEM value="3"/>
     <fontDirectionHint value="2"/>
     <indexToLocFormat value="0"/>
-    <glyphDataFormat value="1"/>
+    <glyphDataFormat value="0"/>
   </head>
 
   <hhea>

--- a/tests/data/figArnaud.otf.ttx
+++ b/tests/data/figArnaud.otf.ttx
@@ -104,7 +104,7 @@
     <lowestRecPPEM value="3"/>
     <fontDirectionHint value="2"/>
     <indexToLocFormat value="0"/>
-    <glyphDataFormat value="1"/>
+    <glyphDataFormat value="0"/>
   </head>
 
   <hhea>

--- a/tests/data/notosanscjksc.otf.ttx
+++ b/tests/data/notosanscjksc.otf.ttx
@@ -35,7 +35,7 @@
     <lowestRecPPEM value="3"/>
     <fontDirectionHint value="2"/>
     <indexToLocFormat value="0"/>
-    <glyphDataFormat value="1"/>
+    <glyphDataFormat value="0"/>
   </head>
 
   <hhea>


### PR DESCRIPTION
This also adds a flag to opt-out of subroutinizing CFF(2).