### PR TITLE
Improve axis-value-label-based automatic instances: don't require _all_ axes to have labels

### DIFF
--- a/src/fontra_compile/compile_fontmake_action.py
+++ b/src/fontra_compile/compile_fontmake_action.py
@@ -137,6 +137,7 @@ def addInstances(designspacePath):
             for label in axis.axisLabels
         ]
         for axis in axes
+        if axis.axisLabels
     ]
 
     axesByName = {axis.name: axis for axis in dsDoc.axes}

--- a/tests/data/MutatorSansAxisValueLabels-fontmake.ttx
+++ b/tests/data/MutatorSansAxisValueLabels-fontmake.ttx
@@ -1,0 +1,504 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.55">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="space"/>
+    <GlyphID id="2" name="A"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.002"/>
+    <checkSumAdjustment value="0xddeb066b"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Thu Jan 16 18:43:26 2025"/>
+    <modified value="Thu Jan 16 18:43:26 2025"/>
+    <xMin value="20"/>
+    <yMin value="-200"/>
+    <xMax value="450"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="20"/>
+    <minRightSideBearing value="20"/>
+    <xMaxExtent value="450"/>
+    <caretSlopeRise value="1000"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="3"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="3"/>
+    <maxPoints value="16"/>
+    <maxContours value="4"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="382"/>
+    <usWeightClass value="100"/>
+    <usWidthClass value="1"/>
+    <fsType value="00000000 00000100"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="97"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="A" width="396" lsb="20"/>
+    <mtx name="space" width="250" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x61" name="A"/><!-- LATIN SMALL LETTER A -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x61" name="A"/><!-- LATIN SMALL LETTER A -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="A" xMin="20" yMin="0" xMax="376" yMax="700">
+      <contour>
+        <pt x="20" y="0" on="1"/>
+        <pt x="165" y="700" on="1"/>
+        <pt x="200" y="700" on="1"/>
+        <pt x="60" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="75" y="164" on="1"/>
+        <pt x="75" y="200" on="1"/>
+        <pt x="325" y="200" on="1"/>
+        <pt x="325" y="164" on="1"/>
+      </contour>
+      <contour>
+        <pt x="332" y="0" on="1"/>
+        <pt x="192" y="700" on="1"/>
+        <pt x="231" y="700" on="1"/>
+        <pt x="376" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="175" y="661" on="1"/>
+        <pt x="175" y="700" on="1"/>
+        <pt x="222" y="700" on="1"/>
+        <pt x="222" y="661" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="space"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      License same as MutatorMath. BSD 3-clause. [test-token: C]
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.002;NONE;MutatorMathTest-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.002
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-Regular
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      License same as MutatorMath. BSD 3-clause. [test-token: C]
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-Light
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-Regular
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      Medium
+    </namerecord>
+    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-Medium
+    </namerecord>
+    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
+      Black
+    </namerecord>
+    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
+      MutatorMathTest-Black
+    </namerecord>
+    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
+      weight
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      width
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=2 -->
+        <!-- RegionCount=3 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="2">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+          <VarRegionAxis index="1">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=3 -->
+        <NumShorts value="3"/>
+        <!-- VarRegionCount=3 -->
+        <VarRegionIndex index="0" value="0"/>
+        <VarRegionIndex index="1" value="1"/>
+        <VarRegionIndex index="2" value="2"/>
+        <Item index="0" value="[0, 0, 0]"/>
+        <Item index="1" value="[0, 0, 0]"/>
+        <Item index="2" value="[344, 794, -244]"/>
+      </VarData>
+    </VarStore>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=2 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="265"/>  <!-- weight -->
+        <AxisOrdering value="0"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="266"/>  <!-- width -->
+        <AxisOrdering value="1"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=4 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="258"/>  <!-- Light -->
+        <Value value="100.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="2"/>  <!-- ElidableAxisValueName -->
+        <ValueNameID value="2"/>  <!-- Regular -->
+        <Value value="400.0"/>
+      </AxisValue>
+      <AxisValue index="2" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="261"/>  <!-- Medium -->
+        <Value value="600.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="263"/>  <!-- Black -->
+        <Value value="900.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
+
+  <fvar>
+
+    <!-- Weight -->
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>100.0</MinValue>
+      <DefaultValue>100.0</DefaultValue>
+      <MaxValue>900.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+
+    <!-- Width -->
+    <Axis>
+      <AxisTag>wdth</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>0.0</MinValue>
+      <DefaultValue>0.0</DefaultValue>
+      <MaxValue>1000.0</MaxValue>
+      <AxisNameID>257</AxisNameID>
+    </Axis>
+
+    <!-- Light -->
+    <!-- PostScript: MutatorMathTest-Light -->
+    <NamedInstance flags="0x0" postscriptNameID="259" subfamilyNameID="258">
+      <coord axis="wght" value="100.0"/>
+      <coord axis="wdth" value="0.0"/>
+    </NamedInstance>
+
+    <!-- Regular -->
+    <!-- PostScript: MutatorMathTest-Regular -->
+    <NamedInstance flags="0x0" postscriptNameID="260" subfamilyNameID="2">
+      <coord axis="wght" value="400.0"/>
+      <coord axis="wdth" value="0.0"/>
+    </NamedInstance>
+
+    <!-- Medium -->
+    <!-- PostScript: MutatorMathTest-Medium -->
+    <NamedInstance flags="0x0" postscriptNameID="262" subfamilyNameID="261">
+      <coord axis="wght" value="600.0"/>
+      <coord axis="wdth" value="0.0"/>
+    </NamedInstance>
+
+    <!-- Black -->
+    <!-- PostScript: MutatorMathTest-Black -->
+    <NamedInstance flags="0x0" postscriptNameID="264" subfamilyNameID="263">
+      <coord axis="wght" value="900.0"/>
+      <coord axis="wdth" value="0.0"/>
+    </NamedInstance>
+  </fvar>
+
+  <gvar>
+    <version value="1"/>
+    <reserved value="0"/>
+    <glyphVariations glyph="A">
+      <tuple>
+        <coord axis="wght" value="1.0"/>
+        <delta pt="0" x="-30" y="0"/>
+        <delta pt="1" x="-61" y="100"/>
+        <delta pt="2" x="134" y="100"/>
+        <delta pt="3" x="190" y="0"/>
+        <delta pt="5" x="35" y="130"/>
+        <delta pt="7" x="255" y="-44"/>
+        <delta pt="8" x="58" y="0"/>
+        <delta pt="9" x="102" y="100"/>
+        <delta pt="10" x="383" y="100"/>
+        <delta pt="11" x="354" y="0"/>
+        <delta pt="13" x="29" y="100"/>
+        <delta pt="15" x="252" y="-121"/>
+        <delta pt="17" x="344" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="30" y="0"/>
+        <delta pt="1" x="405" y="0"/>
+        <delta pt="2" x="412" y="0"/>
+        <delta pt="3" x="37" y="0"/>
+        <delta pt="5" x="170" y="54"/>
+        <delta pt="7" x="620" y="60"/>
+        <delta pt="8" x="755" y="0"/>
+        <delta pt="9" x="380" y="0"/>
+        <delta pt="10" x="389" y="0"/>
+        <delta pt="11" x="764" y="0"/>
+        <delta pt="13" x="395" y="0"/>
+        <delta pt="15" x="398" y="3"/>
+        <delta pt="17" x="794" y="0"/>
+      </tuple>
+      <tuple>
+        <coord axis="wght" value="1.0"/>
+        <coord axis="wdth" value="1.0"/>
+        <delta pt="0" x="0" y="0"/>
+        <delta pt="1" x="-149" y="0"/>
+        <delta pt="2" x="-106" y="0"/>
+        <delta pt="3" x="63" y="0"/>
+        <delta pt="4" x="-70" y="-60"/>
+        <delta pt="5" x="-70" y="-44"/>
+        <delta pt="6" x="-260" y="-44"/>
+        <delta pt="7" x="-260" y="-60"/>
+        <delta pt="8" x="-345" y="0"/>
+        <delta pt="9" x="-194" y="0"/>
+        <delta pt="10" x="-73" y="0"/>
+        <delta pt="11" x="-224" y="0"/>
+        <delta pt="12" x="-189" y="-3"/>
+        <delta pt="13" x="-189" y="0"/>
+        <delta pt="14" x="-42" y="0"/>
+        <delta pt="15" x="-42" y="-3"/>
+        <delta pt="16" x="0" y="0"/>
+        <delta pt="17" x="-244" y="0"/>
+        <delta pt="18" x="0" y="0"/>
+        <delta pt="19" x="0" y="0"/>
+      </tuple>
+    </glyphVariations>
+  </gvar>
+
+</ttFont>

--- a/tests/data/MutatorSansAxisValueLabels.fontra/font-data.json
+++ b/tests/data/MutatorSansAxisValueLabels.fontra/font-data.json
@@ -1,0 +1,58 @@
+{
+"fontInfo": {
+"familyName": "MutatorMathTest",
+"versionMajor": 1,
+"versionMinor": 2,
+"copyright": "License same as MutatorMath. BSD 3-clause. [test-token: C]",
+"licenseDescription": "License same as MutatorMath. BSD 3-clause. [test-token: C]"
+},
+"axes": {
+"axes": [
+{
+"name": "weight",
+"label": "weight",
+"tag": "wght",
+"minValue": 100,
+"defaultValue": 100,
+"maxValue": 900,
+"mapping": [
+[
+100,
+150
+],
+[
+900,
+850
+]
+],
+"valueLabels": [
+{
+"name": "Light",
+"value": 100
+},
+{
+"name": "Regular",
+"value": 400,
+"elidable": true
+},
+{
+"name": "Medium",
+"value": 600
+},
+{
+"name": "Black",
+"value": 900
+}
+]
+},
+{
+"name": "width",
+"label": "width",
+"tag": "wdth",
+"minValue": 0,
+"defaultValue": 0,
+"maxValue": 1000
+}
+]
+}
+}

--- a/tests/data/MutatorSansAxisValueLabels.fontra/glyph-info.csv
+++ b/tests/data/MutatorSansAxisValueLabels.fontra/glyph-info.csv
@@ -1,0 +1,3 @@
+glyph name;code points
+A;U+0041,U+0061
+space;U+0020

--- a/tests/data/MutatorSansAxisValueLabels.fontra/glyphs/A^1.json
+++ b/tests/data/MutatorSansAxisValueLabels.fontra/glyphs/A^1.json
@@ -1,0 +1,416 @@
+{
+"name": "A",
+"sources": [
+{
+"name": "LightCondensed",
+"layerName": "MutatorSansLightCondensed/foreground",
+"location": {
+"weight": 150,
+"width": 0
+}
+},
+{
+"name": "BoldCondensed",
+"layerName": "MutatorSansBoldCondensed/foreground",
+"location": {
+"weight": 850,
+"width": 0
+}
+},
+{
+"name": "LightWide",
+"layerName": "MutatorSansLightWide/foreground",
+"location": {
+"weight": 150,
+"width": 1000
+}
+},
+{
+"name": "BoldWide",
+"layerName": "MutatorSansBoldWide/foreground",
+"location": {
+"weight": 850,
+"width": 1000
+}
+}
+],
+"layers": {
+"MutatorSansBoldCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": -10,
+"y": 0
+},
+{
+"x": 250,
+"y": 0
+},
+{
+"x": 334,
+"y": 800
+},
+{
+"x": 104,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 110,
+"y": 120
+},
+{
+"x": 580,
+"y": 120
+},
+{
+"x": 580,
+"y": 330
+},
+{
+"x": 110,
+"y": 330
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 390,
+"y": 0
+},
+{
+"x": 730,
+"y": 0
+},
+{
+"x": 614,
+"y": 800
+},
+{
+"x": 294,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 204,
+"y": 540
+},
+{
+"x": 474,
+"y": 540
+},
+{
+"x": 474,
+"y": 800
+},
+{
+"x": 204,
+"y": 800
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 740
+}
+},
+"MutatorSansBoldWide/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 20,
+"y": 0
+},
+{
+"x": 350,
+"y": 0
+},
+{
+"x": 640,
+"y": 800
+},
+{
+"x": 360,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 210,
+"y": 120
+},
+{
+"x": 940,
+"y": 120
+},
+{
+"x": 940,
+"y": 340
+},
+{
+"x": 210,
+"y": 340
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 800,
+"y": 0
+},
+{
+"x": 1270,
+"y": 0
+},
+{
+"x": 930,
+"y": 800
+},
+{
+"x": 480,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 410,
+"y": 540
+},
+{
+"x": 830,
+"y": 540
+},
+{
+"x": 830,
+"y": 800
+},
+{
+"x": 410,
+"y": 800
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 1290
+}
+},
+"MutatorSansLightCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 20,
+"y": 0
+},
+{
+"x": 60,
+"y": 0
+},
+{
+"x": 200,
+"y": 700
+},
+{
+"x": 165,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 75,
+"y": 164
+},
+{
+"x": 325,
+"y": 164
+},
+{
+"x": 325,
+"y": 200
+},
+{
+"x": 75,
+"y": 200
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 332,
+"y": 0
+},
+{
+"x": 376,
+"y": 0
+},
+{
+"x": 231,
+"y": 700
+},
+{
+"x": 192,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 175,
+"y": 661
+},
+{
+"x": 222,
+"y": 661
+},
+{
+"x": 222,
+"y": 700
+},
+{
+"x": 175,
+"y": 700
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 396
+}
+},
+"MutatorSansLightCondensed/support": {
+"glyph": {
+"xAdvance": 930
+}
+},
+"MutatorSansLightWide/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 50,
+"y": 0
+},
+{
+"x": 97,
+"y": 0
+},
+{
+"x": 612,
+"y": 700
+},
+{
+"x": 570,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 245,
+"y": 224
+},
+{
+"x": 945,
+"y": 224
+},
+{
+"x": 945,
+"y": 254
+},
+{
+"x": 245,
+"y": 254
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 1087,
+"y": 0
+},
+{
+"x": 1140,
+"y": 0
+},
+{
+"x": 620,
+"y": 700
+},
+{
+"x": 572,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 570,
+"y": 664
+},
+{
+"x": 620,
+"y": 664
+},
+{
+"x": 620,
+"y": 700
+},
+{
+"x": 570,
+"y": 700
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 1190
+}
+}
+}
+}

--- a/tests/data/MutatorSansAxisValueLabels.fontra/glyphs/space.json
+++ b/tests/data/MutatorSansAxisValueLabels.fontra/glyphs/space.json
@@ -1,0 +1,59 @@
+{
+"name": "space",
+"sources": [
+{
+"name": "LightCondensed",
+"layerName": "MutatorSansLightCondensed/foreground",
+"location": {
+"weight": 150,
+"width": 0
+}
+},
+{
+"name": "BoldCondensed",
+"layerName": "MutatorSansBoldCondensed/foreground",
+"location": {
+"weight": 850,
+"width": 0
+}
+},
+{
+"name": "LightWide",
+"layerName": "MutatorSansLightWide/foreground",
+"location": {
+"weight": 150,
+"width": 1000
+}
+},
+{
+"name": "BoldWide",
+"layerName": "MutatorSansBoldWide/foreground",
+"location": {
+"weight": 850,
+"width": 1000
+}
+}
+],
+"layers": {
+"MutatorSansBoldCondensed/foreground": {
+"glyph": {
+"xAdvance": 250
+}
+},
+"MutatorSansBoldWide/foreground": {
+"glyph": {
+"xAdvance": 250
+}
+},
+"MutatorSansLightCondensed/foreground": {
+"glyph": {
+"xAdvance": 250
+}
+},
+"MutatorSansLightWide/foreground": {
+"glyph": {
+"xAdvance": 250
+}
+}
+}
+}

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -90,6 +90,16 @@ steps:
         """
 steps:
 - input: fontra-read
+  source: "tests/data/MutatorSansAxisValueLabels.fontra"
+- output: compile-fontmake
+  destination: "output-fontmake.ttf"
+""",
+        "MutatorSansAxisValueLabels-fontmake.ttx",
+    ),
+    (
+        """
+steps:
+- input: fontra-read
   source: "tests/data/MutatorSans.fontra"
 - output: compile-fontmake
   options:


### PR DESCRIPTION
Previously, (automatic) static instances were only added if _all_ axes contained at least one axis value label. That was unintuitively strict.